### PR TITLE
Add ingredient suggestion endpoint with query filtering

### DIFF
--- a/backend/app/crud.py
+++ b/backend/app/crud.py
@@ -824,3 +824,31 @@ def search_recipes(
         return [dict(row) for row in cursor.fetchall()]
     finally:
         conn.close()
+
+
+def suggest_ingredients(query: str, limit: int = 15) -> list[dict]:
+    """Wyszukiwanie składników po query"""
+
+    if not query.strip():
+        raise ValueError("Nazwa query nie może być pusta.")
+
+    if limit <= 0 or limit >= 20 :
+        raise ValueError("Parametr limit musi być > 0 < 20.")
+
+
+    conn = get_db_connection()
+    try:
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            SELECT id, name, image_url
+            FROM ingredients
+            WHERE name LIKE LOWER(?)
+            ORDER BY name
+            LIMIT ?
+            """,
+            (f"%{query}%", limit),
+        )
+        return [dict(row) for row in cursor.fetchall()]
+    finally:
+        conn.close()

--- a/backend/app/routes/ingredients.py
+++ b/backend/app/routes/ingredients.py
@@ -43,6 +43,44 @@ async def list_ingredients(skip: int = 0, limit: int = 100):
         ) from exc
 
 
+@router.get("/suggestions", response_model=APIResponse)
+async def get_suggestions(query:str, limit:int = 15) -> APIResponse:
+    """Zwraca sugestie składników na podstawie zapytania.
+
+    Endpoint zwraca listę składników, których nazwa zawiera podany ciąg znaków.
+    Wyniki są posortowane alfabetycznie i ograniczone do określonej liczby.
+
+    Args:
+        query: Ciąg znaków do wyszukania w nazwach składników.
+        limit: Maksymalna liczba sugestii do zwrócenia.
+    Returns:
+        APIResponse: Odpowiedź zawierająca listę sugestii.
+
+    Raises:
+        HTTPException: 400 przy niepoprawnych parametrach.
+        HTTPException: 500 przy błędzie bazy danych.
+    """
+    try:
+
+        suggestions = crud.suggest_ingredients(query, limit)
+
+        suggestion_models = [IngredientResponse.model_validate(item) for item in suggestions]
+
+        message = "Pobrano listę składników." if suggestions else "Nie znaleziono składników."
+        return APIResponse(
+            success=True,
+            data=[item.model_dump() for item in suggestion_models],
+            message=message,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+    except sqlite3.Error as exc:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Błąd bazy danych.",
+        ) from exc
+
+
 @router.get("/{ingredient_id}", response_model=APIResponse)
 async def get_ingredient(ingredient_id: int):
     """Zwraca szczegóły składnika po ID.


### PR DESCRIPTION
This pull request introduces a new feature to provide ingredient suggestions based on user input. The main changes include adding a new endpoint for ingredient suggestions and implementing the supporting logic in the CRUD layer, with appropriate input validation and error handling.

**Ingredient Suggestions Feature:**

* Added a new `GET /ingredients/suggestions` endpoint to return a list of ingredient suggestions based on a query string, sorted alphabetically and limited by a specified number. The endpoint includes input validation and proper error handling for invalid parameters and database errors. (`backend/app/routes/ingredients.py`)
* Implemented the `suggest_ingredients` function in the CRUD layer to query the `ingredients` table for names matching the input query, with validation to ensure the query is not empty and the limit is within the allowed range. (`backend/app/crud.py`)

Closes #16 